### PR TITLE
Add ip aware auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ You can also allow/deny list specific [paths](https://github.com/spiffe/spiffe/b
 ```yaml
 server:
   auth:
+    acl:
+      ip: resources/example_ip_policy.csv
+      domain: resources/example_domain_policy.csv
     ca:
       root_bundle: test/ca.pem
       trust_domain: example.com
@@ -133,7 +136,6 @@ Clients then have to be configured to use a SPIFFE compatible client certificate
 client:
   socks5: true
   auth:
-    acl: path/to/acl.csv
     ca:
       key: test/client-key.pem
       cert: test/client.pem
@@ -141,27 +143,58 @@ client:
 
 Check out [cfssl](https://github.com/cloudflare/cfssl) for an easy way to run a CA.
 
-### Access Control
+## Access Control
 This project utilizes [casbin](https://github.com/casbin/casbin) to provide a flexible access control policy language.  
 Use the `acl` parameter to point to a policy CSV.
 
-Policy lines take the form 
+There are two ACL files for the server, configured with the following properties in your `config.yaml`
+- `server.auth.acl.ip`,  for filtering IP addresses (which is all there is to go on in a SOCKS proxy) 
+- `server.auth.acl.doman`, for filtering on hostnames (for example, with an HTTP PROXY)
 
-```p, <subject>, <ip:port>, <tcp/udp>, <allow/deny>```
 
-`deny` takes precedence over `allow`.  `*` matches are allowed for `subjects` or in `ip:port` matches.
+### IP ACL Entries
 
-Example policy file
-```casbincsv
-p, spiffe://example.com/users/*, 34.117.59.81:443, tcp, allow
-p, spiffe://example.com/users/good-user-123, *:*, tcp, allow
-p, spiffe://example.com/users/good-user-123, *:80, tcp, deny
-p, spiffe://example.com/users/good-user-456, *:443, tcp, allow
-p, spiffe://example.com/users/bad-user-*, *:*, tcp, deny
+```
+p, <subject/role>, <IP Address or CIDR>, <port>, <tcp/udp>, <allow/deny>
 ```
 
+### Domain ACL Entries 
+(look very similar, but they match on a domain name instead of being able to do IP network matching) 
 
-# TODO:
+```
+p, <subject/role>, <*-globbable domain name>, <port>, <tcp/udp>, <allow/deny>
+```
 
-* Unify firewall and casbin code
-* Change casbin model to seperate IP and port, to allow for ip masking/CIDRs
+### Groups
+
+Groups are supported with a `g` line.  Identities can be associated to groups with `*` glob matching.
+
+For example: 
+
+```casbincsv
+g, spiffe://example.com/users/test-*, role_test
+```
+
+Would add all users in this trust domain whose name starts with `test-` in to the `role_test` group.
+
+### General Rules
+- `deny` takes precedence over `allow`.
+- `*` matches are allowed for `subjects` or in `port` matches.
+
+
+###  Example 
+Domain policy file
+```casbincsv
+p, spiffe://example.com/users/*, ifconfig.me, 443, tcp, allow
+
+p, role_giphy, *.giphy.com, 443, tcp, allow
+p, role_giphy, giphy.com, 443, tcp, allow
+p, role_giphy, s3.amazonaws.com, 443, tcp, allow
+
+
+g, spiffe://example.com/users/good-user-123, role_giphy
+g, spiffe://example.com/users/ok-user-456, role_giphy
+```
+- All users can use https://ifconfig.me
+- We have a role named `role_giphy`, which is allowed to see images on https://giphy.com
+- Users `good-user-123` and `ok-user-456` belong to `role_giphy`, thus are allowed to access https://giphy.com 

--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ Would add all users in this trust domain whose name starts with `test-` in to th
 - `*` matches are allowed for `subjects` or in `port` matches.
 
 
-###  Example 
-Domain policy file
+##  Example 
+
+### Domain policy file
 ```casbincsv
 p, spiffe://example.com/users/*, ifconfig.me, 443, tcp, allow
 
@@ -198,3 +199,15 @@ g, spiffe://example.com/users/ok-user-456, role_giphy
 - All users can use https://ifconfig.me
 - We have a role named `role_giphy`, which is allowed to see images on https://giphy.com
 - Users `good-user-123` and `ok-user-456` belong to `role_giphy`, thus are allowed to access https://giphy.com 
+
+
+
+### IP policy file
+```casbincsv
+p, spiffe://example.com/users/good-user-123, 0.0.0.0/0, 443, tcp, allow
+p, spiffe://example.com/users/good-user-123, 34.117.59.81/32, 80, tcp, allow
+p, *, 1.2.3.4/30, *, tcp, deny
+```
+- Let `good-user-123` use any endpoint, as long is it's on port 443
+- Let `good-user-123` talk to `34.117.59.81` only on port 80 
+- Deny all users access to the `1.2.3.4/30` subnet 

--- a/cli/server.go
+++ b/cli/server.go
@@ -33,7 +33,7 @@ var (
 			}
 			var authorizer auth.Authorize
 			authorizer = auth.NoopAuthorizer()
-			if serverConfig.Auth.AclPolicyPath != "" {
+			if serverConfig.Auth.AclPolicyPath.IpPath != "" || serverConfig.Auth.AclPolicyPath.DomainPath != "" {
 				authorizer = auth.NewPolicyEnforcer(serverConfig.Auth.AclPolicyPath)
 
 			}

--- a/config/application.go
+++ b/config/application.go
@@ -108,7 +108,7 @@ type ApplicationConfig struct {
 }
 
 type ClientConfig struct {
-	EnableProxy              bool
+	EnableProxy              bool `mapstructure:"proxy"`
 	EnableSocks5             bool `mapstructure:"socks5"`
 	HttpProxyPort            int
 	Socks5Port               int
@@ -130,7 +130,11 @@ type ClientAuthConfig struct {
 
 type ServerAuthConfig struct {
 	CaConfig      ServerAuthCaConfig `mapstructure:"ca"`
-	AclPolicyPath string             `mapstructure:"acl"`
+	AclPolicyPath AclCollection      `mapstructure:"acl"`
+}
+type AclCollection struct {
+	IpPath     string `mapstructure:"ip"`
+	DomainPath string `mapstructure:"domain"`
 }
 
 type PathsConfig struct {

--- a/resources/basic_policy.csv
+++ b/resources/basic_policy.csv
@@ -1,5 +1,5 @@
-p, spiffe://example.com/users/*, 34.117.59.81:443, tcp, allow
-p, spiffe://example.com/users/good-user-123, *:*, tcp, allow
-p, spiffe://example.com/users/good-user-123, *:80, tcp, deny
-p, spiffe://example.com/users/good-user-456, *:443, tcp, allow
-p, spiffe://example.com/users/bad-user-*, *:*, tcp, deny
+p, spiffe://example.com/users/*, 34.117.59.81, 443, tcp, allow
+p, spiffe://example.com/users/good-user-123, *, *, tcp, allow
+p, spiffe://example.com/users/good-user-123, *, 80, tcp, deny
+p, spiffe://example.com/users/good-user-456, *, 443, tcp, allow
+p, spiffe://example.com/users/bad-user-*, *, *, tcp, deny

--- a/resources/example_domain_policy.csv
+++ b/resources/example_domain_policy.csv
@@ -1,0 +1,8 @@
+p, *, ifconfig.me, 443, tcp, allow
+
+p, role_giphy, *.giphy.com, 443, tcp, allow
+p, role_giphy, giphy.com, 443, tcp, allow
+p, role_giphy, s3.amazonaws.com, 443, tcp, allow
+
+
+g, spiffe://example.com/users/good-user-123, role_giphy

--- a/resources/example_ip_policy.csv
+++ b/resources/example_ip_policy.csv
@@ -1,0 +1,3 @@
+p, spiffe://example.com/users/good-user-123, 0.0.0.0/0, 443, tcp, allow
+p, spiffe://example.com/users/good-user-123, 34.117.59.81/32, 80, tcp, allow
+

--- a/server/auth/authorize.go
+++ b/server/auth/authorize.go
@@ -18,5 +18,5 @@ func NewForwardAction(subject Subject, destinationAddr, netType string) ForwardA
 }
 
 type Authorize interface {
-	AuthorizeForward(forwardAction ForwardAction) (bool, Subject)
+	AuthorizeForward(forwardAction ForwardAction) bool
 }

--- a/server/auth/noopAuthenticate.go
+++ b/server/auth/noopAuthenticate.go
@@ -23,8 +23,8 @@ func (*noopAuthAuthorizer) Authenticate(w http.ResponseWriter, r *http.Request) 
 	return true, noopAnonymousSubject
 }
 
-func (*noopAuthAuthorizer) AuthorizeForward(forwardAction ForwardAction) (bool, Subject) {
-	return true, noopAnonymousSubject
+func (*noopAuthAuthorizer) AuthorizeForward(forwardAction ForwardAction) bool {
+	return true
 }
 
 func (f *noopAuthAuthorizer) Start() {

--- a/server/auth/policyEnforcerAuthorizer.go
+++ b/server/auth/policyEnforcerAuthorizer.go
@@ -1,44 +1,90 @@
 package auth
 
 import (
+	"edgeproxy/config"
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	fileadapter "github.com/casbin/casbin/v2/persist/file-adapter"
+	"github.com/casbin/casbin/v2/util"
 	"github.com/fsnotify/fsnotify"
 	log "github.com/sirupsen/logrus"
+	"net"
+	"strings"
 )
 
 type policyEnforcer struct {
-	Enforcer      *casbin.Enforcer
-	aclPolicyPath string
+	IpEnforcer          *casbin.Enforcer
+	DomainEnforcer      *casbin.Enforcer
+	ipAclPolicyPath     string
+	domainAclPolicyPath string
 }
 
-const edgeproxyCasbinModel = `[request_definition]
-r = sub, obj, act
+const edgeproxyIpFilteringCasbinModel = `[request_definition]
+r = sub, ip, port, proto
 
 [policy_definition]
-p = sub, obj, act, eft
+p = sub, ip, port, proto, eft
 
 [policy_effect]
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
+[role_definition]
+g = _, _
+
 [matchers]
-m = globMatch(r.sub, p.sub) && globMatch(r.obj, p.obj) && r.act == p.act
+m = globMatch(r.sub, p.sub) && ipMatch(r.ip, p.ip) && globMatch(r.port, p.port) && r.proto == p.proto
 `
 
-func NewPolicyEnforcer(aclPolicyPath string) *policyEnforcer {
-	adapter := fileadapter.NewAdapter(aclPolicyPath)
+const edgeproxyDomainFilteringCasbinModel = `[request_definition]
+r = sub, domain, port, proto
 
-	model, _ := model.NewModelFromString(edgeproxyCasbinModel)
-	enforcer, err := casbin.NewEnforcer(model, adapter)
-	enforcer.SetAdapter(adapter)
+[policy_definition]
+p = sub, domain, port, proto, eft
 
+[policy_effect]
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
+
+[role_definition]
+g = _, _
+
+[matchers]
+m = g(r.sub, p.sub) && globMatch(r.domain, p.domain) && globMatch(r.port, p.port) && r.proto == p.proto
+`
+
+func NewPolicyEnforcer(aclPolicyPath config.AclCollection) *policyEnforcer {
+
+	// IP ACL is mandatory, even if it's just 0.0.0.0/0 on all ports to everyone
+	ipAdapter := fileadapter.NewAdapter(aclPolicyPath.IpPath)
+	ipModel, _ := model.NewModelFromString(edgeproxyIpFilteringCasbinModel)
+
+	ipEnforcer, err := casbin.NewEnforcer(ipModel, ipAdapter)
 	if err != nil {
-		log.Fatalf("cannot load casbin: %v", err)
+		log.Fatalf("cannot load casbin ipModel: %v", err)
 	}
+	ipEnforcer.SetAdapter(ipAdapter)
+	var domainEnforcer *casbin.Enforcer
+	var domainEnforcerErr error
+
+	// add a second enforcer for domain-name matching that can use globs
+	if aclPolicyPath.DomainPath != "" {
+		domainAdapter := fileadapter.NewAdapter(aclPolicyPath.DomainPath)
+		domainModel, _ := model.NewModelFromString(edgeproxyDomainFilteringCasbinModel)
+
+		domainEnforcer, domainEnforcerErr = casbin.NewEnforcer(domainModel, domainAdapter)
+		if domainEnforcerErr != nil {
+			log.Fatalf("cannot load casbin domainModel: %v", domainEnforcerErr)
+		}
+		domainEnforcer.SetAdapter(domainAdapter)
+		// https://casbin.org/docs/en/rbac#use-pattern-matching-in-rbac
+		domainEnforcer.AddNamedMatchingFunc("g", "", util.KeyMatch)
+		domainEnforcer.BuildRoleLinks()
+	}
+
 	pe := &policyEnforcer{
-		Enforcer:      enforcer,
-		aclPolicyPath: aclPolicyPath,
+		IpEnforcer:          ipEnforcer,
+		DomainEnforcer:      domainEnforcer,
+		ipAclPolicyPath:     aclPolicyPath.IpPath,
+		domainAclPolicyPath: aclPolicyPath.DomainPath,
 	}
 	go pe.watchForPolicyChanges()
 	return pe
@@ -58,11 +104,19 @@ func (p *policyEnforcer) watchForPolicyChanges() error {
 				}
 				log.Debugf("event: %v", event)
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					log.Debugf("Enforcer policy file change detected")
-					if err = p.Enforcer.LoadPolicy(); err != nil {
-						log.Error("Error reloading enforcer policy")
+					log.Debugf("Policy file change detected, reloading")
+					if err = p.IpEnforcer.LoadPolicy(); err != nil {
+						log.Error("Error reloading IpEnforcer policy")
 					} else {
-						log.Infof("Enforcer Policy Updated")
+						log.Infof("IpEnforcer Policy Updated")
+					}
+					if p.DomainEnforcer != nil {
+						if err = p.DomainEnforcer.LoadPolicy(); err != nil {
+							log.Error("Error reloading DomainEnforcer policy")
+						} else {
+							log.Infof("DomainEnforcer Policy Updated")
+						}
+						p.DomainEnforcer.BuildRoleLinks()
 					}
 				}
 			case err, ok := <-w.Errors:
@@ -74,20 +128,41 @@ func (p *policyEnforcer) watchForPolicyChanges() error {
 		}
 	}()
 
-	if err = w.Add(p.aclPolicyPath); err != nil {
+	if err = w.Add(p.ipAclPolicyPath); err != nil {
 		return err
+	}
+	if p.domainAclPolicyPath != "" {
+		if err = w.Add(p.domainAclPolicyPath); err != nil {
+			return err
+		}
 	}
 	return nil
 }
-func (p *policyEnforcer) AuthorizeForward(forwardAction ForwardAction) (bool, Subject) {
-	ok, err := p.Enforcer.Enforce(forwardAction.Subject.GetSubject(), forwardAction.DestinationAddr, forwardAction.NetType)
-	if err != nil {
-		log.Error(err)
-		return false, nil
-	}
-	if !ok {
-		return false, nil
+func (p *policyEnforcer) AuthorizeForward(forwardAction ForwardAction) bool {
+	splitAddress := strings.Split(forwardAction.DestinationAddr, ":")
+	host := splitAddress[0]
+
+	var authorized bool
+	var authErr error
+
+	// determine if IP or hostname
+	addr := net.ParseIP(host)
+	if addr != nil {
+		authorized, authErr = p.IpEnforcer.Enforce(forwardAction.Subject.GetSubject(), host, splitAddress[1], forwardAction.NetType)
+	} else {
+		authorized, authErr = p.DomainEnforcer.Enforce(forwardAction.Subject.GetSubject(), host, splitAddress[1], forwardAction.NetType)
+		if authErr != nil && authorized {
+			// TODO: resolve the IP address, then additionally check it against the IpEnforcer
+		}
 	}
 
-	return true, forwardAction.Subject
+	if authErr != nil {
+		log.Error(authErr)
+		return false
+	}
+	if !authorized {
+		return false
+	}
+
+	return true
 }

--- a/server/handlers/tunnel.go
+++ b/server/handlers/tunnel.go
@@ -54,7 +54,7 @@ func (t *tunnelHandler) TunnelHandler(authenticate auth.Authenticate, authorizer
 			// run this subject and the requested network action through casbin
 			subj := subject.GetSubject()
 			forwardAction := auth.NewForwardAction(subject, dstAddr, netType)
-			if policyRes, _ := authorizer.AuthorizeForward(forwardAction); policyRes {
+			if policyRes := authorizer.AuthorizeForward(forwardAction); policyRes {
 				//TODO support http2, if is available prefered over WebSocket
 				wsConn, err := t.upgrader.Upgrade(res, req, nil)
 				if err != nil {

--- a/test/client-ca.yaml
+++ b/test/client-ca.yaml
@@ -1,5 +1,6 @@
 client:
   socks5: true
+  proxy: true
   auth:
     ca:
       key: test/client-1-key.pem

--- a/test/server-ca.yaml
+++ b/test/server-ca.yaml
@@ -1,6 +1,8 @@
 server:
   auth:
-    acl: resources/basic_policy.csv
+    acl:
+      ip: resources/example_ip_policy.csv
+      domain: resources/example_domain_policy.csv
     ca:
       root_bundle: test/ca.pem
       trust_domain: example.com


### PR DESCRIPTION
So I realized, if we wanna do IP-aware policy files, we probably have to actually use _2_ policy files, one for network matching (useful when doing a SOCKS5) , and a second for hostname matching (when doing an HTTP PROXY)

This commit also adds groups/roles to both IP and Domain policy files